### PR TITLE
Use GitHub OIDC for Codecov actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ jobs:
     name: Lint and Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,20 +38,19 @@ jobs:
       #   if: always()
 
       - name: Try build
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: yarn run build
 
       - name: Upload test results to codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
+          report_type: test_results
           files: junit.xml,typecheck.junit.xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
           files: coverage/clover.xml

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -12,9 +12,11 @@ export default defineConfig({
 			rollupTypes: true,
 		}),
 		codecovVitePlugin({
-			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			enableBundleAnalysis: true,
 			bundleName: "raindrop-client",
-			uploadToken: process.env.CODECOV_TOKEN,
+			oidc: {
+				useGitHubOIDC: true,
+			},
 		}),
 	],
 	build: {


### PR DESCRIPTION
Replace Codecov upload token with GitHub OIDC.