### PR TITLE
Use trusted publishers for publishing package to npm

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,12 +4,12 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
-
 jobs:
   build-docs:
     name: Build Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
-
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     environment: npm
     steps:
       - name: Checkout
@@ -24,7 +25,7 @@ jobs:
           node-version-file: .node-version
           cache: yarn
           registry-url: https://registry.npmjs.org
-          scope: '@lasuillard'
+          scope: "@lasuillard"
 
       - name: Install deps
         run: yarn install --frozen-lockfile
@@ -42,6 +43,4 @@ jobs:
           files: dist.tar.gz
 
       - name: Publish package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn publish


### PR DESCRIPTION
Migrate current token-based authentication for npm to OIDC-based trusted publishing.